### PR TITLE
エラー処理を変更

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,9 +5,6 @@ class API::BaseController < ApplicationController
   private
   
     def render_404(exception = nil)
-      respond_to do |format|
-        format.json { render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found }
-        format.html { render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html' }
-      end
+      render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found
     end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,13 @@
+class API::BaseController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+
+  private
+  
+    def render_404(exception = nil)
+      respond_to do |format|
+        format.json { render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found }
+        format.html { render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html' }
+      end
+    end
+end

--- a/app/controllers/api/v1/users/microposts_controller.rb
+++ b/app/controllers/api/v1/users/microposts_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module Users
-      class MicropostsController < ApplicationController
+      class MicropostsController < API::BaseController
 
         def index
           user = User.find(params[:user_id])  

--- a/app/controllers/api/v1/users/microposts_controller.rb
+++ b/app/controllers/api/v1/users/microposts_controller.rb
@@ -11,10 +11,6 @@ module Api
           gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
           gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=80"
           render json: {user_name: user.name, icon_url: gravatar_url, microposts: microposts}
-          
-        rescue ActiveRecord::RecordNotFound
-          response.status = 404
-          render json: {message: "Validation Failed"}
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  rescue_from ActionController::RoutingError, with: :render_404
 
   private
-  
-    def render_404(exception = nil)
-      respond_to do |format|
-        format.json { render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found }
-        format.html { render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html' }
-      end
-    end
   
     # ユーザーのログインを確認する
     def logged_in_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,19 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
 
+  def render_404(exception = nil)
+    if request.format.to_sym == :json
+      render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found
+    else
+      render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
+    end
+  end
+  
   private
-
+  
     # ユーザーのログインを確認する
     def logged_in_user
       unless logged_in?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,9 @@ class ApplicationController < ActionController::Base
   private
   
     def render_404(exception = nil)
-      if request.format.to_sym == :json
-        render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found
-      else
-        render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
+      respond_to do |format|
+        format.json { render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found }
+        format.html { render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html' }
       end
     end
   

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,15 +4,15 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::RoutingError, with: :render_404
 
-  def render_404(exception = nil)
-    if request.format.to_sym == :json
-      render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found
-    else
-      render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
-    end
-  end
-  
   private
+  
+    def render_404(exception = nil)
+      if request.format.to_sym == :json
+        render json: { status: 404, error: (exception ? exception.message : 'not_found') }, status: :not_found
+      else
+        render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
+      end
+    end
   
     # ユーザーのログインを確認する
     def logged_in_user

--- a/spec/requests/microposts_api_spec.rb
+++ b/spec/requests/microposts_api_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "microposts api", type: :request do
     end
 
     context "ユーザーIDが存在していない場合" do
-      let!(:id) { 500 }
+      let!(:id) { -1 }
       before { get "/api/v1/users/#{id}/microposts" }
       
       it "リクエストが失敗していること" do

--- a/spec/requests/microposts_api_spec.rb
+++ b/spec/requests/microposts_api_spec.rb
@@ -49,14 +49,15 @@ RSpec.describe "microposts api", type: :request do
     end
 
     context "ユーザーIDが存在していない場合" do
-      before { get "/api/v1/users/500/microposts" }
+      let!(:id) { 500 }
+      before { get "/api/v1/users/#{id}/microposts" }
       
       it "リクエストが失敗していること" do
         expect(response.status).to eq(404)
       end
       
       it "エラーメッセージが返ってきていること" do
-        expect(json["message"]).to eq("Validation Failed")   
+        expect(json["error"]).to eq("Couldn't find User with 'id'=#{id}")   
       end
     end
   end


### PR DESCRIPTION
今まで存在しないuser_idが受け取ったときにjsonでメッセージを返していたが、そのメッセージにidもつけてステータスも返すように。それとroutingエラーとの見分けがつくように。
json形式の指定がなければ404.htmlを表示（元からそうだったかもしれないが明示的に）