### PR TITLE
POST する際は Content-Type ヘッダーを必須とする

### DIFF
--- a/api.md
+++ b/api.md
@@ -92,6 +92,11 @@
 #### HTTPメソッド
 - POST
 
+#### リクエストヘッダ
+
+- Content-Type (required)
+  - 常に `application/json` とする
+
 #### 入力（リクエスト）
 - user_id(Integer, required)
   - フォローする側のユーザーID
@@ -176,6 +181,11 @@
 
 #### HTTPメソッド
 - POST
+
+#### リクエストヘッダ
+
+- Content-Type (required)
+  - 常に `application/json` とする
 
 #### 入力（リクエスト）
 - user_id(Integer, required)


### PR DESCRIPTION
レビューのときに指摘するのを忘れていました。
POST の API が呼ばれるときには「何らかのデータ」を受け取ることが多いと思いますが、その形式を表現する `Content-Type` ヘッダーについて定義が漏れていました。
`Content-Type` ヘッダーは「クライアントが POST するデータの形式はどういうものか」を表現するものです。ここでは値を `application/json` 固定にして、JSON 以外のデータは受け取らないという意図を表現しています。
(`application/json` というのは MIME タイプと呼ばれるもので、データ形式ごとに値が決まっています。例えば画像の場合は `image/jpeg` とか)