### PR TITLE
ログインバリデーションAPIのリクエストヘッダーを追加

### DIFF
--- a/api.md
+++ b/api.md
@@ -187,7 +187,10 @@
   - type
     - `Token`
   - credentials
-    - remember_tokenを載せる
+    - remember_tokenを記載
+  - 例
+    `Authorization: "Token HogehogeToken"`
+
 
 #### リクエストヘッダ
 

--- a/api.md
+++ b/api.md
@@ -184,7 +184,10 @@
 
 #### リクエストヘッダー
 - Authorization
-  - remember_tokenを受け取る
+  - type
+    - `Token`
+  - credentials
+    - remember_tokenを載せる
 
 #### リクエストヘッダ
 

--- a/api.md
+++ b/api.md
@@ -182,9 +182,9 @@
 #### HTTPメソッド
 - GET
 
-#### HTTPリクエストヘッダー
+#### リクエストヘッダー
 - Authorization
-  - remember_tokenが入っている
+  - remember_tokenを受け取る
 
 #### リクエストヘッダ
 


### PR DESCRIPTION
フォローAPIからログインバリデーションAPIへremember_tokenを送る時、リクエストヘッダーを通して送るような仕様を記述（変更）。
ここの仕様に問題なければ、#29でのプルリクを見直した後マージするような流れ。
[特にここら辺のプルリク](https://github.com/t-training/sample_app/pull/29#discussion_r431714187)